### PR TITLE
Feature/#30

### DIFF
--- a/src/main/java/com/playdata/article/controller/ArticleController.java
+++ b/src/main/java/com/playdata/article/controller/ArticleController.java
@@ -7,6 +7,8 @@ import com.playdata.domain.article.request.ArticleCategoryRequest;
 import com.playdata.domain.article.request.ArticleRequest;
 import com.playdata.domain.article.response.ArticleResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -29,13 +31,28 @@ public class ArticleController {
         articleService.insert(articleRequest, tokenInfo.getId());
     }
 
-    @GetMapping
+//    @GetMapping
+//    //질문 조회
+//    @ResponseStatus(HttpStatus.OK)
+//    public List<ArticleResponse> getAll()
+//    {
+//        return articleService.getAll();
+//    }
+
     //질문 조회
+    @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public List<ArticleResponse> getAll()
+    public Page<ArticleResponse> getAll(@RequestParam(value ="page",required = false,defaultValue = "0")Integer page,
+                                        @RequestParam(value="size", required = false, defaultValue = "10")Integer size,
+                                        ArticleCategoryRequest articleCategoryRequest)
     {
-        return articleService.getAll();
+        return articleService.getAll(PageRequest.of(page,size),articleCategoryRequest);
     }
+
+
+
+
+
     //질문 삭제
     @DeleteMapping("{id}")
     public void deleteArticle(@AuthenticationPrincipal TokenInfo tokenInfo,@PathVariable Long id)
@@ -49,13 +66,13 @@ public class ArticleController {
         return articleService.updateArticle(tokenInfo,id,articleRequest);
 
     }
-    //질문 카테고리 조회
-    @GetMapping("/category")
-    @ResponseStatus(HttpStatus.OK)
-    public List<ArticleResponse> getByCategory(@RequestBody ArticleCategoryRequest articleCategoryRequest)
-    {
-        return articleService.getByCategory(articleCategoryRequest);
-    }
+//    //질문 카테고리 조회
+//    @GetMapping("/category")
+//    @ResponseStatus(HttpStatus.OK)
+//    public List<ArticleResponse> getByCategory(@RequestBody ArticleCategoryRequest articleCategoryRequest)
+//    {
+//        return articleService.getByCategory(articleCategoryRequest);
+//    }
 //    질문 상세 조회
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/com/playdata/article/service/ArticleService.java
+++ b/src/main/java/com/playdata/article/service/ArticleService.java
@@ -10,6 +10,8 @@ import com.playdata.domain.article.request.ArticleRequest;
 import com.playdata.domain.article.response.ArticleResponse;
 import com.playdata.kafka.QuestionProducer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -29,20 +31,25 @@ public class ArticleService {
     }
 
 
-    public List<ArticleResponse> getAll()
+//    public List<ArticleResponse> getAll()
+//    {
+//        List<Article> getArticles = articleRepository.findAll();
+//        return getArticles.stream().map(ArticleResponse::new).toList();
+//    }
+    public Page<ArticleResponse> getAll(PageRequest pageRequest, ArticleCategoryRequest articleCategoryRequest)
     {
-        List<Article> getArticles = articleRepository.findAll();
-        return getArticles.stream().map(ArticleResponse::new).toList();
+        return articleRepository.getArticleByCategory(pageRequest,articleCategoryRequest);
     }
 
 
 
-    public List<ArticleResponse> getByCategory(ArticleCategoryRequest articleCategoryRequest)
-    {
-        List<ArticleResponse> getArticleByCategory = articleRepository.getArticleByCategory(articleCategoryRequest);
-        return getArticleByCategory;
 
-    }
+//    public List<ArticleResponse> getByCategory(ArticleCategoryRequest articleCategoryRequest)
+//    {
+//        List<ArticleResponse> getArticleByCategory = articleRepository.getArticleByCategory(articleCategoryRequest);
+//        return getArticleByCategory;
+//
+//    }
     // id로 article 찾아옴
     public Article findById(Long id)
     {

--- a/src/main/java/com/playdata/domain/article/repository/ArticleQueryDslRepository.java
+++ b/src/main/java/com/playdata/domain/article/repository/ArticleQueryDslRepository.java
@@ -3,11 +3,13 @@ package com.playdata.domain.article.repository;
 import com.playdata.domain.article.entity.Article;
 import com.playdata.domain.article.request.ArticleCategoryRequest;
 import com.playdata.domain.article.response.ArticleResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 public interface ArticleQueryDslRepository {
-    List<ArticleResponse> getArticleByCategory(ArticleCategoryRequest articleCategoryRequest);
+    Page<ArticleResponse> getArticleByCategory(PageRequest pageRequest, ArticleCategoryRequest articleCategoryRequest);
 
 }

--- a/src/main/java/com/playdata/domain/article/request/ArticleCategoryRequest.java
+++ b/src/main/java/com/playdata/domain/article/request/ArticleCategoryRequest.java
@@ -1,13 +1,14 @@
 package com.playdata.domain.article.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.List;
 
 
-@Getter
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
 public class ArticleCategoryRequest {
-    private String catecory;
+    private String category;
 }

--- a/src/main/java/com/playdata/domain/article/request/ArticleRequest.java
+++ b/src/main/java/com/playdata/domain/article/request/ArticleRequest.java
@@ -14,12 +14,14 @@ import java.util.UUID;
 public class ArticleRequest {
     private String content;
     private String title;
+    private String category;
     public Article toEntity(UUID memberId)
     {
         return Article
                 .builder()
                 .content(content)
                 .title(title)
+                .category(category)
                 .member(Member.builder().id(memberId).build())
                 .build();
     }

--- a/src/main/java/com/playdata/question.http
+++ b/src/main/java/com/playdata/question.http
@@ -2,12 +2,15 @@
 GET http://localhost:8082/api/v1/question/article
 Accept: application/json
 
+
 ### insertArticle(질문 작성)
 POST http://localhost:8082/api/v1/question/article
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWQiOiI5NjlkZDlhMi0wMWM3LTRhZjQtODFkOS01ZWFmZjk0MjMwNDQiLCJwcm9maWxlSW1hZ2VVcmwiOiJwcm9maWxlSW1hZ2VVcmwiLCJlbWFpbCI6IjIiLCJleHAiOjE2OTg2NDA3ODN9.hTGyKHXJDiYGImGNLFwnrnbSFkOfCLeC5b-N9k2VSAo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWQiOiI5NGRmZjQ0OS04MmU4LTQ4OGQtOWM4Ni01MTE4ZjI0ZTI5MjEiLCJwcm9maWxlSW1hZ2VVcmwiOiJwcm9maWxlSW1hZ2VVcmwiLCJlbWFpbCI6IjYiLCJleHAiOjE2OTg3NDc2ODl9.6MJ5Rwmr8vllzoBmDgL1D9Y72ghsRq3GqJVzFSwRHgU
 Content-Type: application/json
 
 {
+  "category": "공부",
+  "difficulty": "어려움",
   "title" : "질문입니다.",
   "content": "알려주세요"
 


### PR DESCRIPTION
querydsl을 통한 전체 검색 및 카테고리 검색 부분 수정

querydsl을 사용하는 이유는 동적인 쿼리를 사용하기 위해 들어오는 parameter의 따라서 조건을 걸어서 가져와야하는데
원래 만들어 있는 코드에서는 카테고리 한 개만을 통해서
(조건 x or 카테고리 1개 ) 이러한 형태로만 사용하기 때문에 원하는대로 여러가지 카테고리를 선택하여 가져오는 식의 방법에 적합 하지 않았습니다.

따라서 조건의 or형태의 여러가지 조건이 필요하였고 이에 따라서 booleanbuilder를 사용하여 or조건을 통해서 list의 데이터를 foreach 형태로 조건을 걸어주도록 설정하였습니다.

이렇게 수정을 하여 복수조건으로 or로 여러개의 카테고리를 list로 다중검색을 할 수 있도록 변경하였습니다.

