### PR TITLE
Feature/#32

### DIFF
--- a/src/main/java/com/playdata/article/controller/ArticleController.java
+++ b/src/main/java/com/playdata/article/controller/ArticleController.java
@@ -5,6 +5,7 @@ import com.playdata.config.TokenInfo;
 import com.playdata.domain.article.entity.Article;
 import com.playdata.domain.article.request.ArticleCategoryRequest;
 import com.playdata.domain.article.request.ArticleRequest;
+import com.playdata.domain.article.response.ArticleDetailResponse;
 import com.playdata.domain.article.response.ArticleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,7 +20,7 @@ import java.util.List;
 //추후 수정 mapping 주소
 @RequestMapping("/api/v1/question/article")
 @RequiredArgsConstructor
-@CrossOrigin(origins = "http://localhost:3000")
+@CrossOrigin(origins = "http://localhost:3000", allowCredentials = "true")
 
 public class ArticleController {
     private final ArticleService articleService;
@@ -43,8 +44,8 @@ public class ArticleController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public Page<ArticleResponse> getAll(@RequestParam(value ="page",required = false,defaultValue = "0")Integer page,
-                                        @RequestParam(value="size", required = false, defaultValue = "10")Integer size,
-                                        ArticleCategoryRequest articleCategoryRequest)
+                                                       @RequestParam(value="size", required = false, defaultValue = "10")Integer size,
+                                                       ArticleCategoryRequest articleCategoryRequest)
     {
         return articleService.getAll(PageRequest.of(page,size),articleCategoryRequest);
     }
@@ -76,7 +77,7 @@ public class ArticleController {
 //    질문 상세 조회
     @GetMapping("/{id}")
     @ResponseStatus(HttpStatus.OK)
-    public ArticleResponse getById(@PathVariable("id")Long id)
+    public ArticleDetailResponse getById(@PathVariable("id")Long id)
     {
         return articleService.getById(id);
     }

--- a/src/main/java/com/playdata/article/service/ArticleService.java
+++ b/src/main/java/com/playdata/article/service/ArticleService.java
@@ -7,6 +7,7 @@ import com.playdata.domain.article.kafka.ArticleKafka;
 import com.playdata.domain.article.repository.ArticleRepository;
 import com.playdata.domain.article.request.ArticleCategoryRequest;
 import com.playdata.domain.article.request.ArticleRequest;
+import com.playdata.domain.article.response.ArticleDetailResponse;
 import com.playdata.domain.article.response.ArticleResponse;
 import com.playdata.kafka.QuestionProducer;
 import lombok.RequiredArgsConstructor;
@@ -59,10 +60,10 @@ public class ArticleService {
         return article;
     }
 //    상세 article
-    public ArticleResponse getById(Long id)
+    public ArticleDetailResponse getById(Long id)
     {
         Article article =findById(id);
-        return new ArticleResponse(article);
+        return new ArticleDetailResponse(article);
     }
 
     public void deleteById(TokenInfo tokenInfo,Long id)

--- a/src/main/java/com/playdata/domain/article/dto/ArticleDto.java
+++ b/src/main/java/com/playdata/domain/article/dto/ArticleDto.java
@@ -12,10 +12,12 @@ public class ArticleDto {
     private Long id;
     private String title;
     private String content;
+    private String category;
 
     public ArticleDto(Article article) {
         this.id = article.getId();
         this.title = article.getTitle();
         this.content = article.getContent();
+        this.category = article.getCategory();
     }
 }

--- a/src/main/java/com/playdata/domain/article/repository/ArticleQueryDslRepository.java
+++ b/src/main/java/com/playdata/domain/article/repository/ArticleQueryDslRepository.java
@@ -2,6 +2,7 @@ package com.playdata.domain.article.repository;
 
 import com.playdata.domain.article.entity.Article;
 import com.playdata.domain.article.request.ArticleCategoryRequest;
+import com.playdata.domain.article.response.ArticleDetailResponse;
 import com.playdata.domain.article.response.ArticleResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;

--- a/src/main/java/com/playdata/domain/article/repository/ArticleQueryDslRepositoryImpl.java
+++ b/src/main/java/com/playdata/domain/article/repository/ArticleQueryDslRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.playdata.domain.article.repository;
 
 import com.playdata.domain.article.entity.Article;
+import com.playdata.domain.article.entity.QArticle;
 import com.playdata.domain.article.request.ArticleCategoryRequest;
+import com.playdata.domain.article.response.ArticleDetailResponse;
 import com.playdata.domain.article.response.ArticleResponse;
+
 
 import com.playdata.domain.article.response.QArticleResponse;
 import com.querydsl.core.BooleanBuilder;
@@ -33,6 +36,7 @@ public class ArticleQueryDslRepositoryImpl implements ArticleQueryDslRepository{
 
     @Override
     public Page<ArticleResponse> getArticleByCategory(PageRequest pageRequest, ArticleCategoryRequest articleCategoryRequest) {
+        //수정해서 query를 적게 치게 끔 변경 필요
         JPAQuery<ArticleResponse> query =jpaQueryFactory.select(new QArticleResponse(article))
                 .from(article).where((isCategory(articleCategoryRequest.getCategory())
                         )

--- a/src/main/java/com/playdata/domain/article/response/ArticleDetailResponse.java
+++ b/src/main/java/com/playdata/domain/article/response/ArticleDetailResponse.java
@@ -1,0 +1,32 @@
+package com.playdata.domain.article.response;
+
+import com.playdata.domain.article.dto.ArticleDto;
+import com.playdata.domain.article.entity.Article;
+import com.playdata.domain.comment.dto.CommentDto;
+import com.playdata.domain.comment.response.CommentResponse;
+import com.playdata.domain.member.entity.Member;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+//@AllArgsConstructor
+//@NoArgsConstructor
+@Getter
+public class ArticleDetailResponse extends ArticleDto {
+
+    private List<CommentDto> comments;
+    private Member member;
+
+    public ArticleDetailResponse(Article article)
+    {
+        super(article);
+        this.member=article.getMember();
+        this.comments = article.getComments() != null ?
+                article.getComments()
+                        .stream()
+                        .map(CommentDto::new).toList() :new ArrayList<>();
+
+    }
+}

--- a/src/main/java/com/playdata/domain/article/response/ArticleResponse.java
+++ b/src/main/java/com/playdata/domain/article/response/ArticleResponse.java
@@ -3,37 +3,21 @@ package com.playdata.domain.article.response;
 import com.playdata.domain.article.dto.ArticleDto;
 import com.playdata.domain.article.entity.Article;
 import com.playdata.domain.comment.dto.CommentDto;
+import com.playdata.domain.member.entity.Member;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
 import java.util.List;
 
-//@AllArgsConstructor
-//@NoArgsConstructor
 @Getter
-public class ArticleResponse extends ArticleDto {
-//    private String title;
-//    private String content;
-//    private Member member;
-//    private List<?> commentList;
-    private List<CommentDto> comments;
+public class ArticleResponse extends ArticleDto{
+
+
+
 
     @QueryProjection
     public ArticleResponse(Article article)
     {
         super(article);
-        comments = article.getComments()
-                .stream()
-                .map(CommentDto::new)
-                .toList();
-
-//        this.title=article.getTitle();
-//        this.content=article.getContent();
-//        this.member= article.getMember();
-//        this.commentList = article.getCommentList() != null ?
-//                article.getCommentList()
-//                        .stream()
-//                        .map(CommentResponse::new).toList() :new ArrayList<>();
-
     }
 }

--- a/src/main/java/com/playdata/domain/comment/response/CommentResponse.java
+++ b/src/main/java/com/playdata/domain/comment/response/CommentResponse.java
@@ -3,22 +3,20 @@ package com.playdata.domain.comment.response;
 import com.playdata.domain.article.dto.ArticleDto;
 import com.playdata.domain.comment.dto.CommentDto;
 import com.playdata.domain.comment.entity.Comment;
+import com.playdata.domain.member.entity.Member;
 import lombok.Getter;
 
 
 @Getter
 public class CommentResponse extends CommentDto {
-    //    private Long id;
-//    private String content;
-//    private Member member;
-    private ArticleDto article;
+    private Member member;
+
+
+
 
     public CommentResponse(Comment comment) {
         super(comment);
-        article = new ArticleDto(comment.getArticle());
-//        this.id = comment.getId();
-//        this.content = comment.getContent();
-//        this.member = comment.getMember();
+        this.member=comment.getMember();
     }
 
 

--- a/src/main/java/com/playdata/question.http
+++ b/src/main/java/com/playdata/question.http
@@ -5,7 +5,7 @@ Accept: application/json
 
 ### insertArticle(질문 작성)
 POST http://localhost:8082/api/v1/question/article
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWQiOiI5NGRmZjQ0OS04MmU4LTQ4OGQtOWM4Ni01MTE4ZjI0ZTI5MjEiLCJwcm9maWxlSW1hZ2VVcmwiOiJwcm9maWxlSW1hZ2VVcmwiLCJlbWFpbCI6IjYiLCJleHAiOjE2OTg3NDc2ODl9.6MJ5Rwmr8vllzoBmDgL1D9Y72ghsRq3GqJVzFSwRHgU
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWQiOiIxYmJhZTYzZS04ZmJlLTQ3MTItOTU1ZS00Y2E1NjE5MGI0OGYiLCJwcm9maWxlSW1hZ2VVcmwiOiJwcm9maWxlSW1hZ2VVcmwiLCJlbWFpbCI6IjYiLCJleHAiOjE2OTg3NTg3NTh9.EaIrWPQhE2UarXWiU-DPh3mVnX1lWvhHr6Khl46wHvM
 Content-Type: application/json
 
 {
@@ -37,7 +37,7 @@ Content-Type: application/json
 ### insertComment(댓글 등록)
 POST http://localhost:8082/api/v1/question/comment/1
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWQiOiI5NjlkZDlhMi0wMWM3LTRhZjQtODFkOS01ZWFmZjk0MjMwNDQiLCJwcm9maWxlSW1hZ2VVcmwiOiJwcm9maWxlSW1hZ2VVcmwiLCJlbWFpbCI6IjIiLCJleHAiOjE2OTg2NDA3ODN9.hTGyKHXJDiYGImGNLFwnrnbSFkOfCLeC5b-N9k2VSAo
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6Im5pY2tuYW1lIiwiaWQiOiIxYmJhZTYzZS04ZmJlLTQ3MTItOTU1ZS00Y2E1NjE5MGI0OGYiLCJwcm9maWxlSW1hZ2VVcmwiOiJwcm9maWxlSW1hZ2VVcmwiLCJlbWFpbCI6IjYiLCJleHAiOjE2OTg3NTg3NTh9.EaIrWPQhE2UarXWiU-DPh3mVnX1lWvhHr6Khl46wHvM
 
 {
   "content" : "수정입니다."


### PR DESCRIPTION
Articlle을 response형태로 변경을 한 뒤 직접 가져와 보니 쿼리문이 너무 많이 나가는 것을 확인 하였고 불필요한 필드는 가져오지 않는게 좋다고 판단을 하였습니다.

따라서 전체 질문 글에서는 id(글 id), title(글 제목), content(글 내용)의 데이터만 받아오게 수정을 하였고

전체 글에서 글 id로 상세정보를 확인하였을 때 연관 되어있는 memeber(글 작성자) , comment(list 댓글)을 가져오도록 수정을 하였습니다.