### PR TITLE
queryDSL 조건 추가

### DIFF
--- a/src/main/java/com/playdata/article/controller/ArticleController.java
+++ b/src/main/java/com/playdata/article/controller/ArticleController.java
@@ -41,14 +41,18 @@ public class ArticleController {
     @ResponseStatus(HttpStatus.OK)
     public Page<ArticleResponse> getAll(@RequestParam(value ="page",required = false,defaultValue = "0")int page,
                                         @RequestParam(value="size", required = false, defaultValue = "10")int size,
-                                        @RequestParam(value="category", required = false)  List<String> category)
+                                        @RequestParam(value="category", required = false)  List<String> category,
+                                        @RequestParam(value="keyword", required = false)String keyword)
     {
+        if(keyword==null) {
+            keyword="";
+        }
         if(category==null) {
             List<String> category2 = new ArrayList<>();
-            ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category2.stream().map(Category::valueOf).toList());
+            ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category2.stream().map(Category::valueOf).toList(),keyword);
             return articleService.getAll(PageRequest.of(page,size),articleCategoryRequest);
         }
-        ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category.stream().map(Category::valueOf).toList());
+        ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category.stream().map(Category::valueOf).toList(),keyword);
         return articleService.getAll(PageRequest.of(page,size),articleCategoryRequest);
     }
 

--- a/src/main/java/com/playdata/domain/article/request/ArticleCategoryRequest.java
+++ b/src/main/java/com/playdata/domain/article/request/ArticleCategoryRequest.java
@@ -14,4 +14,5 @@ import java.util.List;
 @Getter
 public class ArticleCategoryRequest {
     private List<Category> category;
+    private String keyword;
 }

--- a/src/main/java/com/playdata/domain/article/response/ArticleDetailResponse.java
+++ b/src/main/java/com/playdata/domain/article/response/ArticleDetailResponse.java
@@ -3,18 +3,13 @@ package com.playdata.domain.article.response;
 import com.playdata.domain.article.dto.ArticleDto;
 import com.playdata.domain.article.entity.Article;
 import com.playdata.domain.comment.dto.CommentDto;
-import com.playdata.domain.comment.response.CommentResponse;
 import com.playdata.domain.member.dto.MemberDto;
-import com.playdata.domain.member.entity.Member;
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-//@AllArgsConstructor
-//@NoArgsConstructor
+
 @Getter
 public class ArticleDetailResponse extends ArticleDto {
 

--- a/src/main/java/com/playdata/domain/comment/response/CommentResponse.java
+++ b/src/main/java/com/playdata/domain/comment/response/CommentResponse.java
@@ -3,21 +3,20 @@ package com.playdata.domain.comment.response;
 import com.playdata.domain.article.dto.ArticleDto;
 import com.playdata.domain.comment.dto.CommentDto;
 import com.playdata.domain.comment.entity.Comment;
+import com.playdata.domain.member.dto.MemberDto;
 import com.playdata.domain.member.entity.Member;
 import lombok.Getter;
 
 
 @Getter
 public class CommentResponse extends CommentDto {
-    private Member member;
+    private MemberDto member;
 
 
 
 
     public CommentResponse(Comment comment) {
         super(comment);
-        this.member=comment.getMember();
+        this.member=new MemberDto(comment.getMember());
     }
-
-
 }


### PR DESCRIPTION
queryDSL 조건을 추가해줬습니다. 버튼으로만 카테고리를 선택하는 것만 구현하였었는데 Text박스에서 검색을 해서 가져오는 조건을 추가 해줬습니다. 또한 어제 말씀 드린 대로 삭제를 할 시 직접 DB에서 삭제를 하는 것이 아닌 Column의 boolean값을 바꿔주어 값을 변경 시켜 검색을 할 때 가져오지 않는 쪽으로 수정을 했기 때문에 그 조건도 추가를 해줬습니다. 또한 질문 글의 상세 페이지에서 댓글을 쓴 유저 정보가 필요하여 dto의 필드도 member 데이터를 가져오는 것으로 수정 하였습니다.