### PR TITLE
Query DSL의 조건 추가 및 삭제 조건 추가

### DIFF
--- a/src/main/java/com/playdata/article/controller/ArticleController.java
+++ b/src/main/java/com/playdata/article/controller/ArticleController.java
@@ -42,17 +42,15 @@ public class ArticleController {
     public Page<ArticleResponse> getAll(@RequestParam(value ="page",required = false,defaultValue = "0")int page,
                                         @RequestParam(value="size", required = false, defaultValue = "10")int size,
                                         @RequestParam(value="category", required = false)  List<String> category,
-                                        @RequestParam(value="keyword", required = false)String keyword)
+                                        @RequestParam(value="keyword", required = false, defaultValue = "")String keyword,
+                                        @RequestParam(value = "orderBy", required = false, defaultValue = "latest")String orderBy)
     {
-        if(keyword==null) {
-            keyword="";
-        }
         if(category==null) {
             List<String> category2 = new ArrayList<>();
-            ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category2.stream().map(Category::valueOf).toList(),keyword);
+            ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category2.stream().map(Category::valueOf).toList(),keyword,orderBy);
             return articleService.getAll(PageRequest.of(page,size),articleCategoryRequest);
         }
-        ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category.stream().map(Category::valueOf).toList(),keyword);
+        ArticleCategoryRequest articleCategoryRequest =new ArticleCategoryRequest(category.stream().map(Category::valueOf).toList(),keyword,orderBy);
         return articleService.getAll(PageRequest.of(page,size),articleCategoryRequest);
     }
 

--- a/src/main/java/com/playdata/article/service/ArticleService.java
+++ b/src/main/java/com/playdata/article/service/ArticleService.java
@@ -1,6 +1,8 @@
 package com.playdata.article.service;
 
 import com.playdata.config.TokenInfo;
+import com.playdata.domain.comment.entity.Comment;
+import com.playdata.domain.comment.repository.CommentRepository;
 import com.playdata.exception.NoArticleByIdException;
 import com.playdata.exception.NotCorrectTokenIdException;
 import com.playdata.domain.article.entity.Article;
@@ -17,6 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -43,8 +46,8 @@ public class ArticleService {
     // id로 article 찾아옴
     public Article findById(Long id)
     {
-        Optional<Article> isIdNull = articleRepository.findById(id);
-        Article article =isIdNull.orElseThrow(()->new NoArticleByIdException("error 500"));
+        Optional<Article>  findAriticleById = articleRepository.findByIdAndAndDeletedAtIsNull(id);
+        Article article = findAriticleById.orElseThrow(()-> new NoArticleByIdException("No Article"));
         return article;
     }
 //    상세 article
@@ -61,10 +64,9 @@ public class ArticleService {
         if(tokenInfo.getId().equals(article.getMember().getId()))
         {
             article.delete();
-            articleRepository.deleteById(article.getId());
         }
         else {
-            throw new NotCorrectTokenIdException("error 401");
+            throw new NotCorrectTokenIdException("Not Correct Token");
         }
     }
     //update
@@ -80,7 +82,7 @@ public class ArticleService {
             return new ArticleResponse(article1);
         }
         else {
-            throw new NotCorrectTokenIdException("error 401");
+            throw new NotCorrectTokenIdException("Not Correct Token");
         }
     }
 

--- a/src/main/java/com/playdata/article/service/ArticleService.java
+++ b/src/main/java/com/playdata/article/service/ArticleService.java
@@ -31,7 +31,6 @@ public class ArticleService {
         Article save = articleRepository.save(articleRequest.toEntity(memberId));
         //send 실패
         questionProducer.send(ArticleKafka.of(save));
-        //
     }
 
     public Page<ArticleResponse> getAll(PageRequest pageRequest, ArticleCategoryRequest articleCategoryRequest)
@@ -61,6 +60,7 @@ public class ArticleService {
         Article article = findById(id);
         if(tokenInfo.getId().equals(article.getMember().getId()))
         {
+            article.delete();
             articleRepository.deleteById(article.getId());
         }
         else {

--- a/src/main/java/com/playdata/comment/service/CommentService.java
+++ b/src/main/java/com/playdata/comment/service/CommentService.java
@@ -26,30 +26,30 @@ public class CommentService {
     private final ArticleRepository articleRepository;
     public void insertComment(CommentRequest commentRequest, Long articleId, UUID memberId)
     {
-        Optional<Article> getArticleById = articleRepository.findById(articleId);
-        getArticleById.orElseThrow(()->new NoArticleByIdException("error 500"));
+        Optional<Article> getArticleById = articleRepository.findByIdAndAndDeletedAtIsNull(articleId);
+        getArticleById.orElseThrow(()->new NoArticleByIdException("No Article"));
         commentRepository.save(commentRequest.toEntity(memberId, articleId));
     }
     @Transactional
     public void deleteComment(TokenInfo tokenInfo, Long id)
     {
         Optional<Comment> getCommentById = commentRepository.findById(id);
-        Comment comment=getCommentById.orElseThrow(()-> new NoArticleByIdException("error 500"));
+        Comment comment=getCommentById.orElseThrow(()-> new NoArticleByIdException("No Comment"));
         if(tokenInfo.getId().equals(comment.getMember().getId())) {
-            commentRepository.deleteById(id);
+            comment.delete();
         }
         else {
-            new NotCorrectTokenIdException("error 401");
+            new NotCorrectTokenIdException("Not Correct Token");
         }
     }
     @Transactional
     public Comment updateComment(TokenInfo tokenInfo,Long id, CommentRequest commentRequest)
     {
         Optional<Comment> getCommentById = commentRepository.findById(id);
-        Comment comment=getCommentById.orElseThrow(()->new NoArticleByIdException("error 500"));
+        Comment comment=getCommentById.orElseThrow(()->new NoArticleByIdException("No Comment"));
         if(tokenInfo.getId().equals(comment.getMember().getId())) comment.setContent(commentRequest.content());
         else {
-            new NotCorrectTokenIdException("error 401");
+            new NotCorrectTokenIdException(("Not Correct Token"));
         }
         return comment;
     }

--- a/src/main/java/com/playdata/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/playdata/domain/article/repository/ArticleRepository.java
@@ -7,9 +7,10 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article,Long>,ArticleQueryDslRepository {
-    @Query("select a.id,a.content,a.category,a.title,c.id,c.content, m.nickname,m.profileImageUrl from Article " +
-            "as a inner join a.comments as c inner join a.member as m where a.id=:id")
-    Optional<Article> findArticleById(Long id);
-
+//    @Query("select a.id,a.content,a.category,a.title, m.nickname,m.profileImageUrl from Article " +
+//            "as a left join a.member as m on a.member.id = m.id" +
+//            " where a.id=:id and a.deletedAt=null")
+//    Optional<Article> findArticleById(Long id);
+    Optional<Article> findByIdAndAndDeletedAtIsNull(Long id);
 
 }

--- a/src/main/java/com/playdata/domain/article/request/ArticleCategoryRequest.java
+++ b/src/main/java/com/playdata/domain/article/request/ArticleCategoryRequest.java
@@ -15,4 +15,5 @@ import java.util.List;
 public class ArticleCategoryRequest {
     private List<Category> category;
     private String keyword;
+    private String orderBy;
 }

--- a/src/main/java/com/playdata/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/playdata/domain/comment/repository/CommentRepository.java
@@ -3,11 +3,18 @@ package com.playdata.domain.comment.repository;
 import com.playdata.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("select c.content ,m.nickname,m.profileImageUrl from Comment" +
+            " as c inner join c.member as m on c.member.id=m.id where c.article.id=:id")
+    List<Comment> findCommentsByArticleId(Long id);
 
 
 

--- a/src/main/java/com/playdata/exception/CustomExceptionAdvice.java
+++ b/src/main/java/com/playdata/exception/CustomExceptionAdvice.java
@@ -17,12 +17,14 @@ public class CustomExceptionAdvice {
     @ExceptionHandler(NoArticleByIdException.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public String resourceNotFoundExceptionHandler(NoArticleByIdException e) {
+        log.error("No Ariticle Exception",e);
         return e.getMessage();
     }
     @ExceptionHandler(ExpiredJwtException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
-    public void weakKeyExceptionHandler(ExpiredJwtException e){
-        log.error("error 401", e);
+    public String weakKeyExceptionHandler(ExpiredJwtException e){
+        log.error("Weakey Exception", e);
+        return e.getMessage();
     }
 
 

--- a/src/main/java/com/playdata/question.http
+++ b/src/main/java/com/playdata/question.http
@@ -5,23 +5,23 @@ Accept: application/json
 
 ### insertArticle(질문 작성)
 POST http://localhost:8082/api/v1/question/article
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuuwlOq_iCIsImlkIjoiYjJmYTBkZmItZDE5My00YjAyLTk0MDYtMzYzMDYwOWNkM2U4IiwicHJvZmlsZUltYWdlVXJsIjoi67CU6r-IIiwiZW1haWwiOiIyMSIsImV4cCI6MTY5OTI2MzMyOX0.br3fzParrtZXh669Ct4dMjZhs2tdnuwPHdskaNH4VMM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuyCrOyekCIsImlkIjoiMTI1MGI2M2QtN2RlMi00MzllLWEzMTktZDY4NDBiMjhjY2Y4IiwicHJvZmlsZUltYWdlVXJsIjoiaHR0cHM6Ly9jZG4ucGl4YWJheS5jb20vcGhvdG8vMjAyMy8wOS8yMS8xOC8xNy9hdXRvbW9iaWxlLTgyNjczNjlfMTI4MC5qcGciLCJlbWFpbCI6IjI3IiwiZXhwIjoxNjk5NDMzMzE2fQ.Z_HZa5MiBx8AkG16AgqH42Q9nE1LKVQMDYEy6wkWqZA
 Content-Type: application/json
 
 {
   "category": "STRESS",
   "difficulty": "어려움",
-  "title" : "시험기간이 2주 남은 대학생입니다. 이번에는 꼭 장학금을 받고 싶은데 어떻게 해야할까요?",
-  "content": "시험공부를 하면서 학점 4.0 이상을 넘어서 장학금을 받고 싶습니다. 학교다니면서 알바까지 하는게 너무 힘듭니다. 받아보신 분들께서 좋은 팁 부탁드립니다."
+  "title" : "새로운글",
+  "content": "새로운글"
 
 }
 
 ### deleteArticle(질문 삭제)
-DELETE http://localhost:8082/api/v1/question/article/4
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuuwlOq_iCIsImlkIjoiYjJmYTBkZmItZDE5My00YjAyLTk0MDYtMzYzMDYwOWNkM2U4IiwicHJvZmlsZUltYWdlVXJsIjoi67CU6r-IIiwiZW1haWwiOiIyMSIsImV4cCI6MTY5OTI0NjM4OX0.v3BLfYhc0I-pMzEhQyhdYpNUqCggWxg2Cn5D3fRFAJs
+DELETE http://localhost:8082/api/v1/question/article/26
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuyCrOyekCIsImlkIjoiMWJlYTJhMzYtN2U4Yi00ZDM1LThjMzQtMGQwNGNkODUwZTExIiwicHJvZmlsZUltYWdlVXJsIjoiaHR0cHM6Ly9jZG4ucGl4YWJheS5jb20vcGhvdG8vMjAyMy8wOS8yMS8xOC8xNy9hdXRvbW9iaWxlLTgyNjczNjlfMTI4MC5qcGciLCJlbWFpbCI6IjI1IiwiZXhwIjoxNjk5NDMwNTM5fQ.avaT-kFDV97a-6thaSC31YBHDiuZGRYRpKhlZ_tXXd8
 
 ### findArticleById(질문 상세조회)
-GET http://localhost:8082/api/v1/question/article/4
+GET http://localhost:8082/api/v1/question/article/27
 Accept: application/json
 
 ### updateArticle(질문 업데이트)
@@ -38,9 +38,9 @@ Content-Type: application/json
 }
 
 ### insertComment(댓글 등록)
-POST http://localhost:8082/api/v1/question/comment/4
+POST http://localhost:8082/api/v1/question/comment/26
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuuwlOq_iCIsImlkIjoiYjJmYTBkZmItZDE5My00YjAyLTk0MDYtMzYzMDYwOWNkM2U4IiwicHJvZmlsZUltYWdlVXJsIjoi67CU6r-IIiwiZW1haWwiOiIyMSIsImV4cCI6MTY5OTI2MzMyOX0.br3fzParrtZXh669Ct4dMjZhs2tdnuwPHdskaNH4VMM
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJuaWNrbmFtZSI6IuyCrOyekCIsImlkIjoiMWJlYTJhMzYtN2U4Yi00ZDM1LThjMzQtMGQwNGNkODUwZTExIiwicHJvZmlsZUltYWdlVXJsIjoiaHR0cHM6Ly9jZG4ucGl4YWJheS5jb20vcGhvdG8vMjAyMy8wOS8yMS8xOC8xNy9hdXRvbW9iaWxlLTgyNjczNjlfMTI4MC5qcGciLCJlbWFpbCI6IjI1IiwiZXhwIjoxNjk5NDMwNTM5fQ.avaT-kFDV97a-6thaSC31YBHDiuZGRYRpKhlZ_tXXd8
 
 
 {


### PR DESCRIPTION
검색을 할 때 사이트들을 찾아보면 조회순, 답글순 , 좋아요 순 등 원하는 정렬대로 리스트가 보여지게 되는데
이를 구현 해보고 싶었고 이러한 정렬이 동적으로 오기 때문에 OrderSpecifier를 사용해 봤습니다. Front에서 조건을 걸어 orderby를 하여 보여지게 될 계획입니다. 또한 원래 삭제를 하게 되면 delete를 했었고 대신 delete를 하면 column의 isDeleted의 column의 boolean true가 되는 식으로 변경이 되었는데 이 때 질문의 경우에는 상관없지만 질문의 달려있는 comment가 삭제 되었을 경우에는 어떻게 할지 고민을 좀 하고 해결 해야 될 것 같습니다.