### PR TITLE
kafka 예외 사항 및 업데이트 시 producer 발행 기능 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,3 @@
 FROM openjdk:17
-# 프로젝트를 복사해서 도커 파일 안에서 빌드를 치고 그 후에 jar 파일을 실행 시킨다.
-#RUN ["mkdir","project"]
-#COPY . ./project
-#RUN ["chmod","744","./project/gradlew"]
-#RUN ["./project/gradlew","clean","build","--no- debug"]
 COPY build/libs/*T.jar app.jar
 ENTRYPOINT ["java","-jar","-Dspring.profiles.active=prod","app.jar"]

--- a/src/main/java/com/playdata/article/service/ArticleService.java
+++ b/src/main/java/com/playdata/article/service/ArticleService.java
@@ -80,6 +80,7 @@ public class ArticleService {
             articleById.setContent(article.getContent());
             articleById.setTitle(article.getTitle());
             articleById.setCategory(article.getCategory());
+            questionProducer.send(ArticleKafka.of(articleById));
             return new ArticleResponse(articleById);
         }
         else {

--- a/src/main/java/com/playdata/kafka/ConsumerConfig.java
+++ b/src/main/java/com/playdata/kafka/ConsumerConfig.java
@@ -4,17 +4,27 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaOperations;
+import org.springframework.kafka.listener.CommonErrorHandler;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.support.converter.JsonMessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
+import org.springframework.util.backoff.FixedBackOff;
 
 @Configuration
 @RequiredArgsConstructor
 public class ConsumerConfig {
     private final KafkaProperties kafkaProperties;
-    //
 
     @Bean
     public RecordMessageConverter converter() {
         return new JsonMessageConverter();
+    }
+
+    @Bean
+    public CommonErrorHandler errorHandler(KafkaOperations<Object,Object> operations){
+        return new DefaultErrorHandler(new DeadLetterPublishingRecoverer(operations),
+                new FixedBackOff(1000L,2));
     }
 }

--- a/src/main/java/com/playdata/kafka/MemberConsumer.java
+++ b/src/main/java/com/playdata/kafka/MemberConsumer.java
@@ -25,4 +25,8 @@ public class MemberConsumer {
             member1.setProfileImageUrl(data.profileImageUrl());
         }
     }
+    @KafkaListener(topics = TopicConfig.memberDLT)
+    public void dltListen(byte[] dlt){
+        System.out.println("dltLinsten : " + new String(dlt));
+    }
 }

--- a/src/main/java/com/playdata/kafka/QuestionProducer.java
+++ b/src/main/java/com/playdata/kafka/QuestionProducer.java
@@ -19,7 +19,9 @@ public class QuestionProducer {
     public void send(ArticleKafka articleKafka) {
         CompletableFuture<SendResult<String, ArticleKafka>> resultCompletableFuture =
                 kafkaTemplate.send(TopicConfig.QUESTION, articleKafka);
-        resultCompletableFuture
+                if(resultCompletableFuture.isCompletedExceptionally()){
+                throw new RuntimeException("send failure");}
+                resultCompletableFuture
                 .thenAccept(result ->
                         System.out.println("send After "
                                 + articleKafka + " "

--- a/src/main/java/com/playdata/kafka/TopicConfig.java
+++ b/src/main/java/com/playdata/kafka/TopicConfig.java
@@ -9,7 +9,13 @@ import org.springframework.kafka.config.TopicBuilder;
 public class TopicConfig {
     public final static String QUESTION = "question"; //내가 발행한 토픽
     public final static String MEMBER = "member"; //내가 구독한 토픽
+    public final static String memberDLT = "member.DLT";
 
+    @Bean
+    public NewTopic memberDLT(){
+        return new NewTopic(memberDLT,1,(short) 1);
+
+    }
     @Bean
     public NewTopic question() {
         return TopicBuilder
@@ -17,10 +23,5 @@ public class TopicConfig {
                 .partitions(1)
                 .replicas(1)
                 .build();
-    }
-
-    @Bean
-    public NewTopic member() {
-        return new NewTopic(MEMBER, 1, (short) 1);
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,9 +4,11 @@ spring:
     username: root
     password: 1q2w3e4r!!
   jpa:
-    hibernate:
-      ddl-auto: update
-    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
   kafka:
     bootstrap-servers: localhost:9092
     consumer:
@@ -19,5 +21,12 @@ spring:
     producer:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
-server:
-  port: 8082
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: debug
+        type:
+          descriptor:
+            sql: trace


### PR DESCRIPTION
kafka가 메시지 유실이 나는 상황이 생길 수 있고 그의 따른 예외 사항을 생각 해 보았습니다. dlt라는 새로운 topic을 발생 시켰고 또한 question이 새로 insert 되었을 때 task 서버에 kafka로 send를 하는데 update를 하는 경우에서도 데이터가 변경되기 때문에 그 상황에서도 send를 하도록 만들었습니다.