### PR TITLE
삭제 comment의 따른 로직 변경

### DIFF
--- a/src/main/java/com/playdata/article/controller/ArticleController.java
+++ b/src/main/java/com/playdata/article/controller/ArticleController.java
@@ -40,14 +40,15 @@ public class ArticleController {
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
     public Page<ArticleResponse> getAll(@RequestParam(value ="page",required = false,defaultValue = "0")int page,
-                                        @RequestParam(value="size", required = false, defaultValue = "10")int size,
+                                        @RequestParam(value="size", required = false, defaultValue = "6")int size,
                                         @RequestParam(value="category", required = false)  List<String> category,
                                         @RequestParam(value="keyword", required = false, defaultValue = "")String keyword,
                                         @RequestParam(value = "orderBy", required = false, defaultValue = "latest")String orderBy)
     {
         if(category==null) {
             List<String> emptyArrayList = new ArrayList<>();
-            ArticleCategoryRequest articleCategoryRequest = getArticleCategoryRequest(keyword, orderBy, emptyArrayList);
+            ArticleCategoryRequest articleCategoryRequest =
+                    getArticleCategoryRequest(keyword, orderBy, emptyArrayList);
             return articleService.getAll(PageRequest.of(page,size),articleCategoryRequest);
         }
         ArticleCategoryRequest articleCategoryRequest = getArticleCategoryRequest(keyword,orderBy,category);

--- a/src/main/java/com/playdata/article/service/ArticleService.java
+++ b/src/main/java/com/playdata/article/service/ArticleService.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class ArticleService {
     private final ArticleRepository articleRepository;
+    private final CommentRepository commentRepository;
     private final QuestionProducer questionProducer;
 
     public void insert(ArticleRequest articleRequest, UUID memberId)
@@ -46,7 +47,7 @@ public class ArticleService {
     // id로 article 찾아옴
     public Article findById(Long id)
     {
-        Optional<Article>  findAriticleById = articleRepository.findByIdAndAndDeletedAtIsNull(id);
+        Optional<Article>  findAriticleById = articleRepository.findArticleById(id);
         Article article = findAriticleById.orElseThrow(()->
                 new NoArticleByIdException("No Article . id = {%s}".formatted(String.valueOf(id))));
         return article;
@@ -55,6 +56,8 @@ public class ArticleService {
     public ArticleDetailResponse getById(Long id)
     {
         Article article =findById(id);
+        List<Comment> commentList = commentRepository.findCommentsByArticleId(id);
+        article.setComments(commentList);
         return new ArticleDetailResponse(article);
     }
 

--- a/src/main/java/com/playdata/comment/service/CommentService.java
+++ b/src/main/java/com/playdata/comment/service/CommentService.java
@@ -30,7 +30,7 @@ public class CommentService {
     private final ArticleRepository articleRepository;
     public void insertComment(CommentRequest commentRequest, Long articleId, UUID memberId)
     {
-        Optional<Article> getArticleById = articleRepository.findByIdAndAndDeletedAtIsNull(articleId);
+        Optional<Article> getArticleById = articleRepository.findArticleById(articleId);
         getArticleById.orElseThrow(()->
                 new NoArticleByIdException("No Article . id = {%s}".formatted(String.valueOf(articleId))));
         commentRepository.save(commentRequest.toEntity(memberId, articleId));

--- a/src/main/java/com/playdata/config/ApplicationConfig.java
+++ b/src/main/java/com/playdata/config/ApplicationConfig.java
@@ -13,21 +13,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @RequiredArgsConstructor
 public class ApplicationConfig {
     private final JwtService jwtService;
-
-    @Value("${config.password.strength}")
-    private int STRENGTH;
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder(STRENGTH);
-    }
-
     @Bean
     public AuthenticationProvider authenticationProvider() {
         DaoAuthenticationProvider authenticationProvider
                 = new DaoAuthenticationProvider();
-
-        authenticationProvider.setPasswordEncoder(passwordEncoder());
         authenticationProvider.setUserDetailsService(jwtService::parseToken);
 
         return authenticationProvider;

--- a/src/main/java/com/playdata/domain/article/repository/ArticleRepository.java
+++ b/src/main/java/com/playdata/domain/article/repository/ArticleRepository.java
@@ -7,11 +7,9 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article,Long>,ArticleQueryDslRepository {
-//    @Query("select a from Article " +
-//            "as a"+
-//            " where a.id=:id and a.deletedAt is null")
-//    Optional<Article> findArticleById(Long id);
-    Optional<Article> findByIdAndAndDeletedAtIsNull(Long id);
+    @Query("select a from Article as a " +
+            "join fetch a.member m where a.id=:id and a.deletedAt is null")
+    Optional<Article> findArticleById(Long id);
 
 
 }

--- a/src/main/java/com/playdata/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/playdata/domain/comment/repository/CommentRepository.java
@@ -12,6 +12,9 @@ import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("select c from Comment as c " +
+            "join fetch c.member where c.article.id=:id and c.deletedAt is null")
+    List<Comment> findCommentsByArticleId(Long id);
 
 
 

--- a/src/main/java/com/playdata/domain/member/dto/MemberDto.java
+++ b/src/main/java/com/playdata/domain/member/dto/MemberDto.java
@@ -3,12 +3,16 @@ package com.playdata.domain.member.dto;
 import com.playdata.domain.member.entity.Member;
 import lombok.Getter;
 
+import java.util.UUID;
+
 @Getter
 public class MemberDto {
+    private UUID id;
     private String nickname;
     private String profileImageUrl;
 
     public MemberDto(Member member) {
+        this.id=member.getId();
         this.nickname = member.getNickname();
         this.profileImageUrl = member.getProfileImageUrl();
     }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -35,7 +35,5 @@ logging:
 config:
   client:
     origin: http://localhost:3000
-  password:
-    strength: 10
   jwt:
     secret: anfoawhfafawkefhbwkjlfeopwehfolawefh


### PR DESCRIPTION
전 코드는 findAriticleByIdDeletedIsNull으로 jpaRepository에서 제공하는 메소드를 사용하여 조건을 걸어 aritlce의 상세 정보를 확인할 때 articleDetailResponse를 가져왔습니다. 그런데 Artilce의 oneToMany List로 된 commentList 또한 삭제가 되지 않은 list만을 가져와야 해서 commentlist 또한 deletedIsNull이라는 조건이 필요했고 한번에 @Query를 통해서 commentlist까지 left fetch join을 해서 가지고 오면 commentlist의 있는 member의 데이터를 가져올 때 더 많은 쿼리가 나가는 것을 확인 했습니다.
따라서 직접 쿼리를 작성해서 @Query를 통해서 article을 가져오고 article.id = comment.artilceId인 조건으로 comment를 따로 가져오는 것으로 수정하였습니다. 그 결과 2번의 쿼리로 가져오게 되는 것을 확인 했습니다.