### PR TITLE
kafka 발행 state 필드 추가

### DIFF
--- a/src/main/java/com/playdata/article/service/ArticleService.java
+++ b/src/main/java/com/playdata/article/service/ArticleService.java
@@ -3,6 +3,7 @@ package com.playdata.article.service;
 import com.playdata.config.TokenInfo;
 import com.playdata.domain.comment.entity.Comment;
 import com.playdata.domain.comment.repository.CommentRepository;
+import com.playdata.domain.member.kafka.Action;
 import com.playdata.exception.NoArticleByIdException;
 import com.playdata.exception.NotCorrectTokenIdException;
 import com.playdata.domain.article.entity.Article;
@@ -34,7 +35,7 @@ public class ArticleService {
     public void insert(ArticleRequest articleRequest, UUID memberId)
     {
         Article save = articleRepository.save(articleRequest.toEntity(memberId));
-        questionProducer.send(ArticleKafka.of(save));
+        questionProducer.send(ArticleKafka.ArticleBuilder(save, Action.valueOf("INSERT")));
     }
 
     public Page<ArticleResponse> getAll(PageRequest pageRequest, ArticleCategoryRequest articleCategoryRequest)
@@ -67,6 +68,7 @@ public class ArticleService {
         Article article = findById(id);
         if(checkTokenAvailabiltiy(tokenInfo, article))
             article.delete();
+        questionProducer.send(ArticleKafka.ArticleBuilder(article, Action.valueOf("DELETE")));
     }
 
     public boolean checkTokenAvailabiltiy(TokenInfo tokenInfo, Article article)
@@ -87,7 +89,7 @@ public class ArticleService {
             articleById.setContent(article.getContent());
             articleById.setTitle(article.getTitle());
             articleById.setCategory(article.getCategory());
-            questionProducer.send(ArticleKafka.of(articleById));
+            questionProducer.send(ArticleKafka.ArticleBuilder(articleById, Action.valueOf("EDIT")));
             return new ArticleResponse(articleById);
     }
 }

--- a/src/main/java/com/playdata/domain/article/kafka/ArticleKafka.java
+++ b/src/main/java/com/playdata/domain/article/kafka/ArticleKafka.java
@@ -1,9 +1,29 @@
 package com.playdata.domain.article.kafka;
 
 import com.playdata.domain.article.entity.Article;
+import com.playdata.domain.member.kafka.Action;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-public record ArticleKafka(Long id, String title, String content) {
-    public static ArticleKafka of(Article article) {
-        return new ArticleKafka(article.getId(), article.getTitle(), article.getContent());
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleKafka {
+    private Long id;
+    private String title;
+    private String content;
+    private Action action;
+    public static ArticleKafka ArticleBuilder(Article article, Action action)
+    {
+        return ArticleKafka
+                .builder()
+                .id(article.getId())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .action(action)
+                .build();
     }
 }

--- a/src/main/java/com/playdata/domain/member/entity/Member.java
+++ b/src/main/java/com/playdata/domain/member/entity/Member.java
@@ -1,5 +1,6 @@
 package com.playdata.domain.member.entity;
 
+import com.playdata.config.BaseEntity;
 import com.playdata.domain.article.entity.Article;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
     @Id
     private UUID id;
     private String nickname;

--- a/src/main/java/com/playdata/domain/member/kafka/Action.java
+++ b/src/main/java/com/playdata/domain/member/kafka/Action.java
@@ -1,0 +1,5 @@
+package com.playdata.domain.member.kafka;
+
+public enum Action {
+    CREATE,DELETE,EDIT
+}

--- a/src/main/java/com/playdata/domain/member/kafka/MemberKafka.java
+++ b/src/main/java/com/playdata/domain/member/kafka/MemberKafka.java
@@ -4,9 +4,10 @@ import com.playdata.domain.member.entity.Member;
 
 import java.util.UUID;
 
-public record MemberKafkaData(String id,
+public record MemberKafka(String id,
                               String nickname,
-                              String profileImageUrl) {
+                              String profileImageUrl,
+                          Action action) {
 
     public Member ToEntity() {
         return Member.builder()

--- a/src/main/java/com/playdata/exception/CustomExceptionAdvice.java
+++ b/src/main/java/com/playdata/exception/CustomExceptionAdvice.java
@@ -18,13 +18,13 @@ public class CustomExceptionAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ExceptionResponse resourceNotFoundExceptionHandler(NoArticleByIdException e) {
         log.error(e.getMessage(),e);
-        return ExceptionResponse.responseBuilder("500",e.getMessage());
+        return ExceptionResponse.responseBuilder(e.getMessage());
     }
     @ExceptionHandler(ExpiredJwtException.class)
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ExceptionResponse weakKeyExceptionHandler(ExpiredJwtException e){
         log.error(e.getMessage(), e);
-        return ExceptionResponse.responseBuilder("401",e.getMessage());
+        return ExceptionResponse.responseBuilder(e.getMessage());
     }
 
 }

--- a/src/main/java/com/playdata/exception/NoMemberByIdException.java
+++ b/src/main/java/com/playdata/exception/NoMemberByIdException.java
@@ -1,0 +1,8 @@
+package com.playdata.exception;
+
+public class NoMemberByIdException extends RuntimeException{
+    public NoMemberByIdException(String message)
+    {
+        super(message);
+    }
+}

--- a/src/main/java/com/playdata/exception/response/ExceptionResponse.java
+++ b/src/main/java/com/playdata/exception/response/ExceptionResponse.java
@@ -10,13 +10,11 @@ import static com.playdata.exception.status.Status.FAILED;
 @Getter
 public class ExceptionResponse {
     private String status;
-    private String code;
     private String message;
-    public static ExceptionResponse responseBuilder(String code, String message) {
+    public static ExceptionResponse responseBuilder(String message) {
         return ExceptionResponse
                 .builder()
                 .status(FAILED.toString())
-                .code(code)
                 .message(message)
                 .build();
     }

--- a/src/main/java/com/playdata/kafka/ConsumerConfig.java
+++ b/src/main/java/com/playdata/kafka/ConsumerConfig.java
@@ -15,7 +15,6 @@ import org.springframework.util.backoff.FixedBackOff;
 @Configuration
 @RequiredArgsConstructor
 public class ConsumerConfig {
-    private final KafkaProperties kafkaProperties;
 
     @Bean
     public RecordMessageConverter converter() {

--- a/src/main/java/com/playdata/kafka/MemberConsumer.java
+++ b/src/main/java/com/playdata/kafka/MemberConsumer.java
@@ -1,28 +1,40 @@
 package com.playdata.kafka;
 
 import com.playdata.domain.member.entity.Member;
-import com.playdata.domain.member.kafka.MemberKafkaData;
+import com.playdata.domain.member.kafka.MemberKafka;
 import com.playdata.domain.member.repository.MemberRepository;
+import com.playdata.exception.NoArticleByIdException;
+import com.playdata.exception.NoMemberByIdException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.ToDoubleBiFunction;
 
 @Component
 @RequiredArgsConstructor
 public class MemberConsumer {
     private final MemberRepository memberRepository;
 
+    // TODO memberListen을 할 때 각각의 action의 따라서 다른 결과가 되어야 함
+    // TODO 현재는 받아서 로직으로 구현 insert, update, delete를 action에서 확인해서 처리
     @KafkaListener(topics = TopicConfig.MEMBER)
-    public void listen(MemberKafkaData data) {
-        Optional<Member> member =memberRepository.findById(UUID.fromString(data.id()));
-        if(member.isEmpty()) memberRepository.save(data.ToEntity());
-        else{
-            Member member1 = member.get();
-            member1.setNickname(data.nickname());
-            member1.setProfileImageUrl(data.profileImageUrl());
+    public void listen(MemberKafka data) {
+        if(data.action().toString().equals("CREATE"))
+        {
+            memberRepository.save(data.ToEntity());
+        }
+        else if(data.action().toString().equals("UPDATE"))
+        {
+            memberRepository.save(data.ToEntity());
+        }
+        else {
+            Optional<Member> getMemberByKafkaData = memberRepository.findById(UUID.fromString(data.id()));
+            Member member = getMemberByKafkaData.orElseThrow(()->
+                    new NoMemberByIdException("No Member . id = {%s}".formatted(data.id())));
+            member.delete();
         }
     }
     @KafkaListener(topics = TopicConfig.memberDLT)


### PR DESCRIPTION
조원 들과 상의 중에 kafka topic을 여러 개로 (insert, delete, update)로 나누어 보낼지 field의 state 타입을 추가해서 producer에서 보내주고 consumer에서 처리 할지를 고민 하던 중 field의 state를 추가해 보내주는 것으로 하였습니다. 