### PR TITLE
kafka send를 위한 category타입 필드 추가

### DIFF
--- a/src/main/java/com/playdata/domain/article/kafka/ArticleKafka.java
+++ b/src/main/java/com/playdata/domain/article/kafka/ArticleKafka.java
@@ -1,7 +1,7 @@
 package com.playdata.domain.article.kafka;
 
 import com.playdata.domain.article.entity.Article;
-import com.playdata.domain.member.kafka.Action;
+import com.playdata.domain.article.entity.Category;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,15 +15,15 @@ public class ArticleKafka {
     private Long id;
     private String title;
     private String content;
-    private Action action;
-    public static ArticleKafka ArticleBuilder(Article article, Action action)
+    private Category category;
+    public static ArticleKafka ArticleBuilder(Article article)
     {
         return ArticleKafka
                 .builder()
                 .id(article.getId())
                 .title(article.getTitle())
                 .content(article.getContent())
-                .action(action)
+                .category(article.getCategory())
                 .build();
     }
 }

--- a/src/main/java/com/playdata/kafka/KafkaData.java
+++ b/src/main/java/com/playdata/kafka/KafkaData.java
@@ -5,11 +5,11 @@ import lombok.Builder;
 
 @Builder
 public record KafkaData<T>(Action action,T data) {
-    public static <T>KafkaData<T> create(T data) {
+    public static <T>KafkaData<T> create(T data, Action action) {
       return KafkaData
               .<T>builder()
               .data(data)
-              .action(Action.CREATE)
+              .action(action)
               .build();
     }
 

--- a/src/main/java/com/playdata/kafka/MemberConsumer.java
+++ b/src/main/java/com/playdata/kafka/MemberConsumer.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Optional;
 import java.util.UUID;
-import java.util.function.ToDoubleBiFunction;
 
 @Component
 @RequiredArgsConstructor
@@ -22,12 +21,10 @@ public class MemberConsumer {
     // TODO 현재는 받아서 로직으로 구현 insert, update, delete를 action에서 확인해서 처리
     @KafkaListener(topics = TopicConfig.MEMBER)
     public void listen(MemberKafka data) {
-        if(data.action().toString().equals("CREATE"))
-        {
+        if(data.action().toString().equals("CREATE")) {
             memberRepository.save(data.ToEntity());
         }
-        else if(data.action().toString().equals("UPDATE"))
-        {
+        else if(data.action().toString().equals("UPDATE")) {
             memberRepository.save(data.ToEntity());
         }
         else {

--- a/src/main/java/com/playdata/kafka/QuestionProducer.java
+++ b/src/main/java/com/playdata/kafka/QuestionProducer.java
@@ -1,6 +1,7 @@
 package com.playdata.kafka;
 
 import com.playdata.domain.article.kafka.ArticleKafka;
+import com.playdata.domain.member.kafka.Action;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -16,17 +17,48 @@ import java.util.concurrent.CompletableFuture;
 public class QuestionProducer {
     private final KafkaTemplate<String, KafkaData<ArticleKafka>> kafkaTemplate;
     @Async
-    public void send(ArticleKafka articleKafka) {
+    public void sendArticleCreate(ArticleKafka articleKafka) {
         CompletableFuture<SendResult<String, KafkaData<ArticleKafka>>> resultCompletableFuture =
-                kafkaTemplate.send(TopicConfig.QUESTION, KafkaData.create(articleKafka));
+                kafkaTemplate.send(TopicConfig.QUESTION,
+                        KafkaData.create(articleKafka, Action.valueOf("CREATE")));
                 if(resultCompletableFuture.isCompletedExceptionally()){
-                throw new RuntimeException("send failure");}
-                resultCompletableFuture
-                .thenAccept(result ->
+                    throw new RuntimeException("send failure");
+                }
+                resultCompletableFuture.thenAccept(result ->
                         System.out.println("send After "
                                 + articleKafka + " "
                                 + result.getRecordMetadata()
                                 .offset()));
+        log.info("send={}",articleKafka);
+    }
+    @Async
+    public void sendArticleDelete(ArticleKafka articleKafka) {
+        CompletableFuture<SendResult<String, KafkaData<ArticleKafka>>> resultCompletableFuture =
+                kafkaTemplate.send(TopicConfig.QUESTION,
+                        KafkaData.create(articleKafka, Action.valueOf("DELETE")));
+        if(resultCompletableFuture.isCompletedExceptionally()){
+            throw new RuntimeException("send failure");
+        }
+        resultCompletableFuture.thenAccept(result ->
+                System.out.println("send After "
+                        + articleKafka + " "
+                        + result.getRecordMetadata()
+                        .offset()));
+        log.info("send={}",articleKafka);
+    }
+    @Async
+    public void sendArticleUpdate(ArticleKafka articleKafka) {
+        CompletableFuture<SendResult<String, KafkaData<ArticleKafka>>> resultCompletableFuture =
+                kafkaTemplate.send(TopicConfig.QUESTION,
+                        KafkaData.create(articleKafka, Action.valueOf("EDIT")));
+        if(resultCompletableFuture.isCompletedExceptionally()){
+            throw new RuntimeException("send failure");
+        }
+        resultCompletableFuture.thenAccept(result ->
+                System.out.println("send After "
+                        + articleKafka + " "
+                        + result.getRecordMetadata()
+                        .offset()));
         log.info("send={}",articleKafka);
     }
 }


### PR DESCRIPTION
카프카를 보내줄 때 category 필드도 추가로 task서비스에서 필요해서 producer가 보내주는 kafka 데이터에 catogory를 추가하였습니다. 또한 기존에는 create가 defalut로 되어있었는데 각각 다른 action타입이 필요했기 때문에 각각의 kafka send 메소드를 타입에 따라 나눠 만들었습니다.